### PR TITLE
fix the Date Picker Crash Bug

### DIFF
--- a/dist/example/input/input.wxml
+++ b/dist/example/input/input.wxml
@@ -67,7 +67,7 @@
                     <view class="weui-label">日期</view>
                 </view>
                 <view class="weui-cell__bd">
-                    <picker mode="date" value="{{date}}" start="2015-09-01" end="2017-09-01" bindchange="bindDateChange">
+                    <picker mode="date" value="{{date}}" bindchange="bindDateChange">
                         <view class="weui-input">{{date}}</view>
                     </picker>
                 </view>


### PR DESCRIPTION
在Picker的属性中，若定义日期区间start="2015-09-01" end="2017-09-01，则必崩溃，删除日期区间则正常。